### PR TITLE
Add `make run` and `make clean` directive

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -7,21 +7,34 @@ DEV_PROJECT := chingu
 .PHONY: test run
 
 test:
+	@ echo "Pulling dependencies from Docker Hub..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) pull
+	@ echo "Building immages..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) build --pull app
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) build --pull test
+	@ echo "Waiting while database is ready..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) run --rm db_probe
+	@ echo "Performing migrations..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) run --rm app run migrate up
-	# Run unit tests
+	@ echo "Running unit tests..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) run --rm app test
-	# Run integration tests
+	@ echo "Running integration tests..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) up test
 
 run:
+	@ echo "Pulling dependencies from Docker Hub..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) pull
+	@ echo "Building immages..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) build --pull app
-	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) build --pull test
+	@ echo "Waiting while database is ready..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) run --rm db_probe
+	@ echo "Performing migrations..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) run --rm app run migrate up
-	# Run server
+	@ echo "Running the app..."
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) up app
+
+clean:
+	@ echo "Cleaning environment..."
+	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) down -v
+	@ docker images -q -f dangling=true -f label=application=$(REPO_NAME) | xargs -I ARGS docker rmi -f ARGS
+	@ echo "Clean complete"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,10 +1,10 @@
 # Filenames
 DEV_COMPOSE_FILE := docker/dev/docker-compose.yml
 
-# Docker Compose Project Names
+# Docker-compose Project Name
 DEV_PROJECT := chingu
 
-.PHONY: test
+.PHONY: test run
 
 test:
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) pull
@@ -16,3 +16,12 @@ test:
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) run --rm app test
 	# Run integration tests
 	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) up test
+
+run:
+	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) pull
+	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) build --pull app
+	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) build --pull test
+	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) run --rm db_probe
+	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) run --rm app run migrate up
+	# Run server
+	@ docker-compose -p $(DEV_PROJECT) -f $(DEV_COMPOSE_FILE) up app


### PR DESCRIPTION
Now you can spin up a local copy of backend with `make run`. Command should be run from `./backend` directory relative to the project root.
Currently it will run node app in the foreground of a terminal, so you can see incoming requests and response status codes there, as well as the framework errors. 

To shut it down CTR-C the app and type `make clean`. This will stop all containers.

Current setup is made to discard db data between runs, to work well with tests in Travis, so If you stop the container all data will be lost. If you want to keep the data, you need to modify `./backend/docker/dev/docker-compose.yml` as follows:
1. Add volume section at the bottom of the file:
```
volumes:
  postgres:
```
2. Plug this volume to the app section like that:
```
...
app:
    volumes:
      - "postgres:/var/lib/postgresql/data"
    build:
...
```